### PR TITLE
Mise à jour de la description de la commande "git-repo" pour préciser…

### DIFF
--- a/src/otterbots/commands/git-repo.ts
+++ b/src/otterbots/commands/git-repo.ts
@@ -3,7 +3,7 @@ import {ChatInputCommandInteraction, ColorResolvable, EmbedBuilder, SlashCommand
 export default {
     data: new SlashCommandBuilder()
         .setName("git-repo")
-        .setDescription("Exemple de commande"),
+        .setDescription("Obtiens le lien du dépôt GitHub du bot."),
     async execute(interaction: ChatInputCommandInteraction): Promise<void> {
         // Récupération de BOT_COLOR et VERSION depuis .env
         const bot_color = process.env.BOT_COLOR || "#FFFFFF";


### PR DESCRIPTION
… qu'elle obtient le lien du dépôt GitHub du bot.